### PR TITLE
**Updated:** VSIX Manifest file to allow Extension to run in Visual S…

### DIFF
--- a/VSIXBundler.Package/source.extension.vsixmanifest
+++ b/VSIXBundler.Package/source.extension.vsixmanifest
@@ -8,15 +8,15 @@
         <ReleaseNotes>index.html</ReleaseNotes>
     </Metadata>
     <Installation>
-        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.0,16.0]" />
-        <InstallationTarget Version="[15.0,16.0)" Id="Microsoft.VisualStudio.Pro" />
-        <InstallationTarget Version="[15.0,16.0)" Id="Microsoft.VisualStudio.Enterprise" />
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.0,17.0]" />
+        <InstallationTarget Version="[15.0,17.0)" Id="Microsoft.VisualStudio.Pro" />
+        <InstallationTarget Version="[15.0,17.0)" Id="Microsoft.VisualStudio.Enterprise" />
     </Installation>
     <Dependencies>
     </Dependencies>
     <Prerequisites>
-        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
-        <Prerequisite Id="Microsoft.Net.ComponentGroup.TargetingPacks.Common" Version="[15.6.27406.0,16.0)" DisplayName=".NET Framework 4 – 4.6 development tools" />
+        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,17.0)" DisplayName="Visual Studio core editor" />
+        <Prerequisite Id="Microsoft.Net.ComponentGroup.TargetingPacks.Common" Version="[15.6.27406.0,17.0)" DisplayName=".NET Framework 4 – 4.6 development tools" />
     </Prerequisites>
     <Assets>
         <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />


### PR DESCRIPTION
I've had a look into this one and I believe these changes should allow the Extension to be installed for Visual Studio 2019.

Original Issue:  [#17 - Update Visual Studio Marketplace Support](https://github.com/FireflyMigration/MultiProject/issues/7)

This involved some minor updates to the Manifest file to allow later Versions of Visual Studio and also updated the Version Range for the 'Microsoft.VisualStudio.Component.CoreEditor' prerequisite.

Hope this helps!